### PR TITLE
[Frontend] STT 결과 화면 개선

### DIFF
--- a/frontend/src/app/stt/page.tsx
+++ b/frontend/src/app/stt/page.tsx
@@ -52,10 +52,8 @@ export default function SttPage() {
     }
 
     // 데모 결과 텍스트
-    const fileNames = files.map((f) => f.name).join(", ");
     setResult(
-      `[STT 변환 결과]\n\n파일: ${fileNames}\n\n` +
-        "안녕하세요, 오늘 강의에서는 데이터 구조의 기본 개념에 대해 알아보겠습니다.\n\n" +
+      "안녕하세요, 오늘 강의에서는 데이터 구조의 기본 개념에 대해 알아보겠습니다.\n\n" +
         "첫 번째로 배열에 대해 설명하겠습니다. 배열은 동일한 타입의 데이터를 연속된 메모리 공간에 저장하는 자료구조입니다.\n\n" +
         "두 번째로 연결 리스트에 대해 알아보겠습니다. 연결 리스트는 각 노드가 데이터와 다음 노드를 가리키는 포인터로 구성됩니다.\n\n" +
         "마지막으로 스택과 큐에 대해 설명하겠습니다. 스택은 LIFO, 큐는 FIFO 방식으로 동작합니다.",
@@ -138,7 +136,12 @@ export default function SttPage() {
           <Card>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <CardTitle>변환 결과</CardTitle>
+                <div>
+                  <CardTitle>변환 결과</CardTitle>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {files.map((f) => f.name).join(", ")}
+                  </p>
+                </div>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={handleCopy}>
                     <Copy className="w-4 h-4" />
@@ -160,7 +163,7 @@ export default function SttPage() {
           <div className="flex justify-center">
             <Button variant="outline" onClick={handleReset}>
               <RotateCcw className="w-4 h-4" />
-              새로운 변환
+              다시 변환하기
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## 개요
STT 변환 결과 화면의 UX를 개선한다.

## 변경 사항
- 결과 텍스트에서 `[STT 변환 결과]`/`파일:` 메타데이터를 제거하고 순수 변환 텍스트만 표시
- 파일명을 CardHeader 영역에 별도 UI 요소로 표시
- "새로운 변환" 버튼 텍스트를 자연스러운 "다시 변환하기"로 변경

## 테스트
- [x] STT 변환 결과 페이지에서 메타데이터 없이 순수 텍스트만 표시되는지 확인
- [x] CardHeader에 파일명이 정상 표시되는지 확인
- [x] "다시 변환하기" 버튼 동작 확인

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 음성 및 영상 파일을 자동으로 텍스트로 변환하는 기능 추가

* **UI 개선**
  * 변환 결과 화면에서 원본 파일명 표시
  * 변환 버튼 텍스트 업데이트

* **테스트**
  * 음성 변환 기능에 대한 포괄적 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->