### PR TITLE
[Backend] 이력 관리 API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.config import settings
 from app.database import Base, engine
 from app.models import Upload, SttResult, AiSummary  # noqa: F401
 from app.routers import health, upload
+from app.routers.history import router as history_router
 from app.routers.summary import router as summary_router
 
 
@@ -34,3 +35,4 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(upload.router)
 app.include_router(summary_router)
+app.include_router(history_router)

--- a/backend/app/routers/history.py
+++ b/backend/app/routers/history.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.config import settings
+from app.database import get_db
+from app.models.upload import AiSummary, SttResult, Upload
+from app.schemas.history import HistoryDetail, HistoryListItem
+
+router = APIRouter(prefix="/api/v1/history", tags=["history"])
+
+
+@router.get("/", response_model=list[HistoryListItem])
+def list_history(db: Session = Depends(get_db)):
+    """이력 목록을 최신순으로 조회한다."""
+    uploads = (
+        db.query(Upload)
+        .options(joinedload(Upload.stt_results), joinedload(Upload.ai_summaries))
+        .order_by(Upload.created_at.desc())
+        .all()
+    )
+    return [
+        HistoryListItem(
+            id=u.id,
+            file_name=u.file_name,
+            mime_type=u.mime_type,
+            status=u.status,
+            has_stt=len(u.stt_results) > 0,
+            has_summary=len(u.ai_summaries) > 0,
+            created_at=u.created_at,
+        )
+        for u in uploads
+    ]
+
+
+@router.get("/{history_id}", response_model=HistoryDetail)
+def get_history(history_id: str, db: Session = Depends(get_db)):
+    """이력 상세를 조회한다."""
+    upload = (
+        db.query(Upload)
+        .options(joinedload(Upload.stt_results), joinedload(Upload.ai_summaries))
+        .filter(Upload.id == history_id)
+        .first()
+    )
+    if not upload:
+        raise HTTPException(status_code=404, detail="이력을 찾을 수 없습니다.")
+
+    stt = upload.stt_results[0] if upload.stt_results else None
+    summary = upload.ai_summaries[0] if upload.ai_summaries else None
+
+    return HistoryDetail(
+        id=upload.id,
+        file_name=upload.file_name,
+        file_size=upload.file_size,
+        mime_type=upload.mime_type,
+        status=upload.status,
+        stt_content=stt.content if stt else None,
+        summary_content=summary.content if summary else None,
+        summary_provider=summary.provider if summary else None,
+        summary_model=summary.model if summary else None,
+        created_at=upload.created_at,
+    )
+
+
+@router.delete("/{history_id}", status_code=204)
+def delete_history(history_id: str, db: Session = Depends(get_db)):
+    """이력과 관련 데이터를 삭제한다."""
+    upload = db.query(Upload).filter(Upload.id == history_id).first()
+    if not upload:
+        raise HTTPException(status_code=404, detail="이력을 찾을 수 없습니다.")
+
+    # 물리 파일 삭제
+    file_path = Path(upload.file_path).resolve()
+    upload_dir = Path(settings.UPLOAD_DIR).resolve()
+    if file_path.is_relative_to(upload_dir) and file_path.exists():
+        file_path.unlink()
+
+    # 관련 데이터 삭제 (SttResult, AiSummary)
+    db.query(AiSummary).filter(AiSummary.upload_id == history_id).delete()
+    db.query(SttResult).filter(SttResult.upload_id == history_id).delete()
+    db.delete(upload)
+    db.commit()

--- a/backend/app/schemas/history.py
+++ b/backend/app/schemas/history.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class HistoryListItem(BaseModel):
+    """이력 목록 항목."""
+
+    id: str
+    file_name: str
+    mime_type: str
+    status: str
+    has_stt: bool
+    has_summary: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class HistoryDetail(BaseModel):
+    """이력 상세."""
+
+    id: str
+    file_name: str
+    file_size: int
+    mime_type: str
+    status: str
+    stt_content: str | None = None
+    summary_content: str | None = None
+    summary_provider: str | None = None
+    summary_model: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,0 +1,92 @@
+import io
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.upload import AiSummary, SttResult, Upload
+
+
+class TestListHistory:
+    def test_empty_history(self, client: TestClient):
+        response = client.get("/api/v1/history/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_returns_uploads(self, client: TestClient):
+        # 파일 2개 업로드
+        client.post("/api/v1/upload/", files={"file": ("a.mp3", io.BytesIO(b"audio"), "audio/mpeg")})
+        client.post("/api/v1/upload/", files={"file": ("b.mp3", io.BytesIO(b"audio"), "audio/mpeg")})
+
+        response = client.get("/api/v1/history/")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        # 최신순 확인
+        assert data[0]["file_name"] == "b.mp3"
+        assert data[1]["file_name"] == "a.mp3"
+
+    def test_list_shows_stt_summary_flags(self, client: TestClient, db_session: Session):
+        upload_resp = client.post("/api/v1/upload/", files={"file": ("test.mp3", io.BytesIO(b"audio"), "audio/mpeg")})
+        upload_id = upload_resp.json()["id"]
+
+        # STT 결과 추가
+        stt = SttResult(upload_id=upload_id, content="텍스트")
+        db_session.add(stt)
+        db_session.commit()
+
+        response = client.get("/api/v1/history/")
+        data = response.json()
+        assert data[0]["has_stt"] is True
+        assert data[0]["has_summary"] is False
+
+
+class TestGetHistory:
+    def test_get_detail(self, client: TestClient, db_session: Session):
+        upload_resp = client.post("/api/v1/upload/", files={"file": ("test.mp3", io.BytesIO(b"audio"), "audio/mpeg")})
+        upload_id = upload_resp.json()["id"]
+
+        stt = SttResult(upload_id=upload_id, content="변환 텍스트")
+        db_session.add(stt)
+        db_session.commit()
+
+        summary = AiSummary(upload_id=upload_id, stt_result_id=stt.id, provider="openai", model="gpt-5-mini", content="# 학습 노트")
+        db_session.add(summary)
+        db_session.commit()
+
+        response = client.get(f"/api/v1/history/{upload_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["file_name"] == "test.mp3"
+        assert data["stt_content"] == "변환 텍스트"
+        assert data["summary_content"] == "# 학습 노트"
+        assert data["summary_provider"] == "openai"
+        assert data["summary_model"] == "gpt-5-mini"
+
+    def test_get_nonexistent(self, client: TestClient):
+        response = client.get("/api/v1/history/nonexistent")
+        assert response.status_code == 404
+
+
+class TestDeleteHistory:
+    def test_delete_success(self, client: TestClient, db_session: Session):
+        upload_resp = client.post("/api/v1/upload/", files={"file": ("del.mp3", io.BytesIO(b"audio"), "audio/mpeg")})
+        upload_id = upload_resp.json()["id"]
+
+        stt = SttResult(upload_id=upload_id, content="텍스트")
+        db_session.add(stt)
+        db_session.commit()
+
+        response = client.delete(f"/api/v1/history/{upload_id}")
+        assert response.status_code == 204
+
+        # DB에서 삭제 확인
+        assert db_session.query(Upload).filter_by(id=upload_id).first() is None
+        assert db_session.query(SttResult).filter_by(upload_id=upload_id).first() is None
+
+        # 이력 목록에서도 사라짐
+        list_resp = client.get("/api/v1/history/")
+        assert len(list_resp.json()) == 0
+
+    def test_delete_nonexistent(self, client: TestClient):
+        response = client.delete("/api/v1/history/nonexistent")
+        assert response.status_code == 404


### PR DESCRIPTION
## 개요
변환/요약 결과의 이력 저장 및 조회 CRUD API를 구현한다.

## 변경 사항
- GET /api/v1/history/ 이력 목록 조회 (최신순, STT/요약 유무 표시)
- GET /api/v1/history/{id} 이력 상세 조회 (STT/요약 내용 포함)
- DELETE /api/v1/history/{id} 이력 삭제 (관련 데이터 + 물리 파일)
- 파일 삭제 시 UPLOAD_DIR 경계 검증 (Path Traversal 방어)
- 이력 API 테스트 7건 추가 (총 37건 통과)

Closes #22