### PR TITLE
[Backend] PDF/텍스트 파일 직접 요약 지원

### DIFF
--- a/backend/app/services/file_reader.py
+++ b/backend/app/services/file_reader.py
@@ -1,0 +1,47 @@
+"""
+@file file_reader.py
+@description 파일 경로와 MIME 타입으로 텍스트 내용을 추출하는 서비스.
+"""
+
+import logging
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+MAX_TEXT_SIZE = 500 * 1024  # 500KB
+
+
+def read_file_content(file_path: str, mime_type: str) -> str:
+    """파일 경로와 MIME 타입으로 텍스트 내용을 추출한다."""
+    path = Path(file_path).resolve()
+    upload_dir = Path(settings.UPLOAD_DIR).resolve()
+    if not path.is_relative_to(upload_dir):
+        raise ValueError("허용되지 않는 파일 경로입니다.")
+
+    if not path.exists():
+        logger.error("파일을 찾을 수 없습니다: %s", file_path)
+        raise FileNotFoundError("파일을 찾을 수 없습니다.")
+
+    if mime_type == "text/plain":
+        try:
+            content = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            raise ValueError("텍스트 파일을 읽을 수 없어요. UTF-8 인코딩 파일을 사용해주세요.")
+        if len(content) > MAX_TEXT_SIZE:
+            content = content[:MAX_TEXT_SIZE]
+        return content
+
+    if mime_type == "application/pdf":
+        reader = PdfReader(path)
+        text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        if not text.strip():
+            raise ValueError("PDF에서 텍스트를 찾을 수 없어요. 스캔된 이미지 PDF는 지원하지 않아요.")
+        if len(text) > MAX_TEXT_SIZE:
+            text = text[:MAX_TEXT_SIZE]
+        return text
+
+    raise ValueError(f"지원하지 않는 파일 타입입니다: {mime_type}")

--- a/backend/app/services/summary.py
+++ b/backend/app/services/summary.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.models.upload import AiSummary, SttResult, Upload
 from app.prompts.summary import SUMMARY_SYSTEM_PROMPT, build_user_prompt
+from app.services.file_reader import read_file_content
 from app.services.llm import create_provider
 
 logger = logging.getLogger(__name__)
@@ -16,19 +17,25 @@ async def run_summary(
     api_key: str,
     db: Session,
 ) -> AiSummary:
-    """STT 결과를 조회하고 LLM으로 요약한 뒤 DB에 저장한다."""
+    """업로드 파일의 텍스트를 LLM으로 요약한다."""
     upload = db.query(Upload).filter(Upload.id == upload_id).first()
     if not upload:
         raise ValueError("업로드를 찾을 수 없습니다.")
 
+    # STT 결과가 있으면 사용, 없으면 파일에서 직접 추출
     stt_result = (
         db.query(SttResult).filter(SttResult.upload_id == upload_id).first()
     )
-    if not stt_result:
-        raise ValueError("STT 변환 결과가 없습니다. 먼저 STT 변환을 완료해주세요.")
+
+    if stt_result:
+        source_text = stt_result.content
+        stt_result_id = stt_result.id
+    else:
+        source_text = read_file_content(upload.file_path, upload.mime_type)
+        stt_result_id = None
 
     llm = create_provider(provider, api_key, model)
-    user_prompt = build_user_prompt(stt_result.content)
+    user_prompt = build_user_prompt(source_text)
     content = await llm.generate(SUMMARY_SYSTEM_PROMPT, user_prompt)
 
     if not content.strip():
@@ -36,7 +43,7 @@ async def run_summary(
 
     summary = AiSummary(
         upload_id=upload_id,
-        stt_result_id=stt_result.id,
+        stt_result_id=stt_result_id,
         provider=provider,
         model=model,
         content=content,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "openai>=1.60.0",
     "anthropic>=0.42.0",
     "google-genai>=1.0.0",
+    "pypdf>=5.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_file_reader.py
+++ b/backend/tests/test_file_reader.py
@@ -1,0 +1,85 @@
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestReadFileContent:
+    def test_read_text_file(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+
+        txt = tmp_path / "test.txt"
+        txt.write_text("테스트 내용입니다.", encoding="utf-8")
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            result = read_file_content(str(txt), "text/plain")
+
+        assert result == "테스트 내용입니다."
+
+    def test_read_pdf_file(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+        from pypdf import PdfWriter
+
+        pdf_path = tmp_path / "test.pdf"
+        writer = PdfWriter()
+        writer.add_blank_page(width=200, height=200)
+        with open(pdf_path, "wb") as f:
+            writer.write(f)
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            with pytest.raises(ValueError, match="스캔된 이미지 PDF는 지원하지 않아요"):
+                read_file_content(str(pdf_path), "application/pdf")
+
+    def test_file_not_found(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            with pytest.raises(FileNotFoundError, match="파일을 찾을 수 없습니다."):
+                read_file_content(str(tmp_path / "nonexistent.txt"), "text/plain")
+
+    def test_unsupported_mime_type(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+
+        f = tmp_path / "test.bin"
+        f.write_bytes(b"binary data")
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            with pytest.raises(ValueError, match="지원하지 않는 파일 타입"):
+                read_file_content(str(f), "application/octet-stream")
+
+    def test_path_traversal_blocked(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("외부 파일", encoding="utf-8")
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path / "uploads")
+            with pytest.raises(ValueError, match="허용되지 않는 파일 경로"):
+                read_file_content(str(outside_file), "text/plain")
+
+    def test_unicode_decode_error(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content
+
+        f = tmp_path / "bad.txt"
+        f.write_bytes(b"\xff\xfe\x00\x80\x81")
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            with pytest.raises(ValueError, match="UTF-8 인코딩 파일을 사용해주세요"):
+                read_file_content(str(f), "text/plain")
+
+    def test_text_size_truncated(self, tmp_path: Path):
+        from app.services.file_reader import read_file_content, MAX_TEXT_SIZE
+
+        f = tmp_path / "large.txt"
+        f.write_text("A" * (MAX_TEXT_SIZE + 1000), encoding="utf-8")
+
+        with patch("app.services.file_reader.settings") as mock_settings:
+            mock_settings.UPLOAD_DIR = str(tmp_path)
+            result = read_file_content(str(f), "text/plain")
+
+        assert len(result) == MAX_TEXT_SIZE

--- a/backend/tests/test_summary.py
+++ b/backend/tests/test_summary.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
@@ -63,16 +64,34 @@ class TestCreateSummary:
         })
         assert response.status_code == 404
 
-    def test_summary_no_stt_result(self, client: TestClient, db_session: Session):
+    @patch("app.services.file_reader.settings")
+    @patch("app.services.llm.openai.AsyncOpenAI")
+    def test_summary_no_stt_text_file(
+        self, mock_openai_cls, mock_fr_settings, client: TestClient, db_session: Session, tmp_path: Path
+    ):
+        """STT 결과 없는 텍스트 파일 → 파일에서 직접 읽어서 요약 성공."""
+        mock_fr_settings.UPLOAD_DIR = str(tmp_path)
+
+        txt_file = tmp_path / "note.txt"
+        txt_file.write_text("텍스트 파일 내용입니다.", encoding="utf-8")
+
         upload = Upload(
-            file_name="test.mp3",
-            file_path="/fake/test.mp3",
+            file_name="note.txt",
+            file_path=str(txt_file),
             file_size=100,
-            mime_type="audio/mpeg",
-            status="pending",
+            mime_type="text/plain",
+            status="completed",
         )
         db_session.add(upload)
         db_session.commit()
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "# 학습 노트\n\n텍스트 요약"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_openai_cls.return_value = mock_client
 
         response = client.post("/api/v1/summary/", json={
             "upload_id": upload.id,
@@ -80,8 +99,11 @@ class TestCreateSummary:
             "model": "gpt-5-mini",
             "api_key": "test-key",
         })
-        assert response.status_code == 404
-        assert "STT" in response.json()["detail"]
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["upload_id"] == upload.id
+        assert "학습 노트" in data["content"]
 
     def test_summary_invalid_provider(self, client: TestClient):
         response = client.post("/api/v1/summary/", json={

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -797,6 +797,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "openai" },
     { name = "pydantic-settings" },
+    { name = "pypdf" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -816,6 +817,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.60.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pypdf", specifier = ">=5.0.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
@@ -1159,6 +1161,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 개요
학습 노트에서 PDF/텍스트 파일 업로드 시 STT 결과 의존을 제거하고 파일 내용을 직접 읽어 요약한다.

## 변경 사항
- file_reader 서비스 추가: 텍스트/PDF 파일 직접 읽기
- summary 서비스: SttResult 없으면 file_reader로 파일 직접 추출
- Path Traversal 방어 (UPLOAD_DIR 경계 검증)
- 추출 텍스트 크기 제한 (500KB)
- 스캔 PDF 안내: "스캔된 이미지 PDF는 지원하지 않아요"
- UTF-8 인코딩 에러 안내
- pypdf 의존성 추가
- file_reader 테스트 7건 추가 (총 44건 통과)

Closes #38