### PR TITLE
[Frontend] 프론트엔드 마무리 — 이력 API 연동

### DIFF
--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,6 +1,6 @@
 /**
  * @file history/page.tsx
- * @description 변환 이력 페이지. localStorage에 저장된 이력을 조회/삭제한다.
+ * @description 변환 이력 페이지. 백엔드 API에서 이력을 조회/삭제한다.
  */
 
 "use client";
@@ -26,9 +26,9 @@ function formatDate(dateStr: string): string {
 }
 
 export default function HistoryPage() {
-  const { history, removeFromHistory, clearHistory, mounted } = useHistory();
+  const { history, removeFromHistory, clearHistory, mounted, loading } = useHistory();
 
-  if (!mounted) {
+  if (!mounted || loading) {
     return (
       <div className="container mx-auto px-4 py-8 max-w-3xl">
         <div className="animate-pulse space-y-4">
@@ -40,13 +40,13 @@ export default function HistoryPage() {
     );
   }
 
-  const handleDelete = (id: string) => {
-    removeFromHistory(id);
+  const handleDelete = async (id: string) => {
+    await removeFromHistory(id);
     toast.success("이력을 삭제했어요");
   };
 
-  const handleClearAll = () => {
-    clearHistory();
+  const handleClearAll = async () => {
+    await clearHistory();
     toast.success("모든 이력을 삭제했어요");
   };
 
@@ -103,34 +103,38 @@ export default function HistoryPage() {
             {history.map((item) => (
               <div key={item.id} className="flex items-center gap-4 py-4 px-6 hover:bg-muted/30 transition-colors">
                 <div className="flex-shrink-0">
-                  {item.type === "stt" ? (
+                  {item.has_summary ? (
+                    <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-purple-100 dark:bg-purple-900/50">
+                      <FileText className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                    </div>
+                  ) : item.has_stt ? (
                     <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-100 dark:bg-blue-900/50">
                       <Mic className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                     </div>
                   ) : (
-                    <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-purple-100 dark:bg-purple-900/50">
-                      <FileText className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                    <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-muted">
+                      <FileText className="w-5 h-5 text-muted-foreground" />
                     </div>
                   )}
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <p className="font-medium text-foreground truncate">
-                      {item.fileName}
+                      {item.file_name}
                     </p>
-                    <Badge variant={item.type === "stt" ? "default" : "secondary"}>
-                      {item.type === "stt" ? "STT" : "학습 노트"}
+                    <Badge variant={item.has_summary ? "secondary" : "default"}>
+                      {item.has_summary ? "학습 노트" : item.has_stt ? "STT" : "업로드"}
                     </Badge>
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {formatDate(item.createdAt)}
+                    {formatDate(item.created_at)}
                   </p>
                 </div>
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => handleDelete(item.id)}
-                  aria-label={`${item.fileName} 이력 삭제`}
+                  aria-label={`${item.file_name} 이력 삭제`}
                 >
                   <Trash2 className="w-4 h-4" />
                 </Button>

--- a/frontend/src/hooks/useHistory.ts
+++ b/frontend/src/hooks/useHistory.ts
@@ -1,59 +1,68 @@
 /**
  * @file useHistory.ts
- * @description 변환 이력을 localStorage로 관리하는 훅.
+ * @description 변환 이력을 백엔드 API로 관리하는 훅.
  */
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 /** 이력 항목 타입. */
 export interface HistoryItem {
   id: string;
-  fileName: string;
-  type: "stt" | "summary";
-  createdAt: string;
-  data: string;
+  file_name: string;
+  mime_type: string;
+  status: string;
+  has_stt: boolean;
+  has_summary: boolean;
+  created_at: string;
 }
 
-/** localStorage 기반 변환 이력 CRUD 훅. */
+/** 백엔드 API 기반 변환 이력 훅. */
 export function useHistory() {
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [mounted, setMounted] = useState(false);
+  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    setMounted(true);
-    const saved = localStorage.getItem("notebot-history");
-    if (saved) {
-      try {
-        setHistory(JSON.parse(saved));
-      } catch {
-        // 손상된 데이터는 무시
+  const fetchHistory = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/history/`);
+      if (res.ok) {
+        const data = await res.json();
+        setHistory(data);
       }
+    } catch {
+      // 네트워크 에러 무시
+    } finally {
+      setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    if (!mounted) return;
-    localStorage.setItem("notebot-history", JSON.stringify(history));
-  }, [history, mounted]);
+    setMounted(true);
+    fetchHistory();
+  }, [fetchHistory]);
 
-  const addToHistory = (item: Omit<HistoryItem, "id" | "createdAt">) => {
-    const newItem: HistoryItem = {
-      ...item,
-      id: Date.now().toString(),
-      createdAt: new Date().toISOString(),
-    };
-    setHistory((prev) => [newItem, ...prev]);
-  };
+  const removeFromHistory = useCallback(async (id: string) => {
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/history/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setHistory((prev) => prev.filter((item) => item.id !== id));
+      }
+    } catch {
+      // 에러 무시
+    }
+  }, []);
 
-  const removeFromHistory = (id: string) => {
-    setHistory((prev) => prev.filter((item) => item.id !== id));
-  };
-
-  const clearHistory = () => {
+  const clearHistory = useCallback(async () => {
+    // 전체 삭제 API가 없으므로 개별 삭제 반복
+    for (const item of history) {
+      await fetch(`${API_BASE}/api/v1/history/${item.id}`, { method: "DELETE" }).catch(() => {});
+    }
     setHistory([]);
-  };
+  }, [history]);
 
-  return { history, addToHistory, removeFromHistory, clearHistory, mounted };
+  return { history, removeFromHistory, clearHistory, mounted, loading, refetch: fetchHistory };
 }


### PR DESCRIPTION
## 개요
이력 페이지를 localStorage에서 백엔드 API로 전환하여 프론트엔드 마무리.

## 변경 사항
- useHistory 훅: localStorage → GET/DELETE /api/v1/history/ API 연동
- 이력 목록: 파일명, 타입(STT/학습노트/업로드) 뱃지, 날짜 표시
- 개별/전체 삭제 API 연동
- loading 스켈레톤 UI 추가
- localStorage 이력 저장 완전 제거

Closes #18