### PR TITLE
fix: Gemini 2.5 무료 모델 목록 누락 반영

### DIFF
--- a/backend/app/services/llm/gemini.py
+++ b/backend/app/services/llm/gemini.py
@@ -5,7 +5,7 @@ from app.services.llm.base import BaseLLMProvider, LLMAuthError, LLMAPIError, LL
 
 
 class GeminiProvider(BaseLLMProvider):
-    SUPPORTED_MODELS = {"gemini-3.1-pro", "gemini-3-flash", "gemini-3.1-flash-lite"}
+    SUPPORTED_MODELS = {"gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite", "gemini-3-flash", "gemini-3.1-pro", "gemini-3.1-flash-lite"}
 
     async def generate(self, system_prompt: str, user_prompt: str) -> str:
         try:

--- a/backend/tests/test_summary.py
+++ b/backend/tests/test_summary.py
@@ -165,7 +165,7 @@ class TestLLMFactory:
 
     def test_create_gemini(self):
         from app.services.llm.factory import create_provider
-        provider = create_provider("gemini", "key", "gemini-3-flash")
+        provider = create_provider("gemini", "key", "gemini-2.5-flash")
         assert provider.__class__.__name__ == "GeminiProvider"
 
     def test_invalid_provider(self):

--- a/frontend/src/components/LLMSettings.tsx
+++ b/frontend/src/components/LLMSettings.tsx
@@ -36,9 +36,12 @@ const PROVIDER_MODELS: Record<string, ModelInfo[]> = {
     { id: "claude-haiku-4-5", name: "Haiku 4.5", tag: "초고속 · 저비용" },
   ],
   gemini: [
-    { id: "gemini-3-flash", name: "3 Flash", tag: "추천 · 무료" },
-    { id: "gemini-3.1-pro", name: "3.1 Pro", tag: "고성능" },
-    { id: "gemini-3.1-flash-lite", name: "3.1 Flash Lite", tag: "초경량" },
+    { id: "gemini-2.5-flash", name: "2.5 Flash", tag: "추천 · 무료" },
+    { id: "gemini-2.5-pro", name: "2.5 Pro", tag: "고성능 · 무료" },
+    { id: "gemini-2.5-flash-lite", name: "2.5 Flash Lite", tag: "초경량 · 무료" },
+    { id: "gemini-3-flash", name: "3 Flash", tag: "최신 · 유료" },
+    { id: "gemini-3.1-pro", name: "3.1 Pro", tag: "최신 고성능 · 유료" },
+    { id: "gemini-3.1-flash-lite", name: "3.1 Flash Lite", tag: "최신 경량 · 유료" },
   ],
 };
 


### PR DESCRIPTION
## Summary
- PR #43 squash merge 시 누락된 Gemini 2.5 무료 모델 목록 반영
- 백엔드 SUPPORTED_MODELS에 2.5 Flash/Pro/Flash Lite 추가
- 프론트엔드 모델 선택 리스트에 2.5 무료 + 3.x 유료 구분 표시
- 테스트 기본 모델을 gemini-2.5-flash로 변경

## Changed Files
- `backend/app/services/llm/gemini.py`
- `backend/tests/test_summary.py`
- `frontend/src/components/LLMSettings.tsx`