### PR TITLE
docs: README 배지를 backend/frontend 컴포넌트별로 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Release](https://img.shields.io/github/v/release/virtue14/notebot)](https://github.com/virtue14/notebot/releases/latest)
+[![Backend](https://img.shields.io/github/v/tag/virtue14/notebot?filter=notebot-backend-v*&sort=semver&label=backend&color=3776ab)](https://github.com/virtue14/notebot/releases?q=notebot-backend)
+[![Frontend](https://img.shields.io/github/v/tag/virtue14/notebot?filter=notebot-frontend-v*&sort=semver&label=frontend&color=000000)](https://github.com/virtue14/notebot/releases?q=notebot-frontend)
 
 ## 누구를 위한 서비스인가
 


### PR DESCRIPTION
## Summary
- 단일 `latest` release 배지를 **backend/frontend 두 개로 분리**
- shields.io의 `github/v/tag?filter=...` 엔드포인트로 컴포넌트별 최신 SemVer 태그 추출
- 클릭 동선도 분리 — 각 배지가 해당 컴포넌트의 GitHub Releases 검색으로 이동

## 배경
- release-please를 backend/frontend 독립 SemVer로 분리(#107) 후, 태그 명명 규칙이 `notebot-backend-v{x.y.z}` / `notebot-frontend-v{x.y.z}`로 변경됨
- 기존 `github/v/release` 배지는 "latest release" 1개만 표시 → 두 컴포넌트 중 어떤 것의 버전인지 구분 안 됨
- README 헤드에서 양쪽 버전을 한눈에 보여주는 게 더 명확

## 변경 전후

**Before:**
```markdown
[![Release](https://img.shields.io/github/v/release/virtue14/notebot)](https://github.com/virtue14/notebot/releases/latest)
```

**After:**
```markdown
[![Backend](https://img.shields.io/github/v/tag/virtue14/notebot?filter=notebot-backend-v*&sort=semver&label=backend&color=3776ab)](https://github.com/virtue14/notebot/releases?q=notebot-backend)
[![Frontend](https://img.shields.io/github/v/tag/virtue14/notebot?filter=notebot-frontend-v*&sort=semver&label=frontend&color=000000)](https://github.com/virtue14/notebot/releases?q=notebot-frontend)
```

## 동작 방식
- **shields.io 필터:** `notebot-backend-v*` / `notebot-frontend-v*` glob 패턴으로 매칭
- **정렬:** `sort=semver` — 최신 SemVer 태그 자동 선택
- **legacy `v1.0.0` 태그**는 패턴이 다르므로 매칭 안 됨 (이미 deprecated, 우려 없음)
- **색상:** backend Python blue (#3776ab) / frontend Next.js black (#000000) — 시각적 구분

## 주의 — frontend 배지의 임시 상태
- 현재 `notebot-frontend-v*` 태그가 아직 없음 (PR #109 충돌로 대기 중)
- 이 PR 머지 시점엔 frontend 배지에 "no tag found" 또는 빈 값 표시 가능
- 다음 frontend release(release-please가 재생성할 PR 머지 시) 자동으로 채워짐

## Test plan
- [ ] PR 머지 후 README의 backend 배지가 `notebot-backend-v1.1.0` 표시 확인
- [ ] frontend 배지는 첫 frontend release 이후 자동 갱신 확인
- [ ] 각 배지 클릭 시 해당 컴포넌트의 releases 검색 페이지로 이동 확인