### PR TITLE
feat(backend): STT 변환 정확도 옵션 강화 (v1.5 M0)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,13 @@ class Settings(BaseSettings):
     MAX_UPLOAD_SIZE: int = 100 * 1024 * 1024  # 100MB
     WHISPER_MODEL: str = "base"
     WHISPER_DEVICE: str = "cpu"
+    STT_LANGUAGE: str = "ko"
+    STT_VAD_ENABLED: bool = True
+    STT_VAD_MIN_SILENCE_MS: int = 500
+    STT_DEFAULT_INITIAL_PROMPT: str = (
+        "다음은 한국어 강의 또는 학습 자료 녹음입니다. "
+        "강의, 교재, 노트, 정리, 챕터, 예제, 핵심 정리."
+    )
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 

--- a/backend/app/services/stt.py
+++ b/backend/app/services/stt.py
@@ -30,7 +30,20 @@ def get_model() -> WhisperModel:
 def transcribe_file(file_path: str) -> str:
     """파일 경로를 받아 STT 변환 텍스트를 반환한다."""
     model = get_model()
-    segments, _ = model.transcribe(file_path, beam_size=5)
+    transcribe_kwargs: dict = {
+        "language": settings.STT_LANGUAGE,
+        "beam_size": 5,
+        "initial_prompt": settings.STT_DEFAULT_INITIAL_PROMPT,
+        "compression_ratio_threshold": 2.4,
+        "no_speech_threshold": 0.6,
+        "temperature": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+    }
+    if settings.STT_VAD_ENABLED:
+        transcribe_kwargs["vad_filter"] = True
+        transcribe_kwargs["vad_parameters"] = {
+            "min_silence_duration_ms": settings.STT_VAD_MIN_SILENCE_MS,
+        }
+    segments, _ = model.transcribe(file_path, **transcribe_kwargs)
     text = " ".join(segment.text.strip() for segment in segments)
     if not text.strip():
         raise ValueError("STT 변환 결과가 비어 있습니다.")

--- a/backend/tests/test_stt.py
+++ b/backend/tests/test_stt.py
@@ -24,7 +24,17 @@ class TestTranscribeFile:
         result = transcribe_file("/fake/path.mp3")
 
         assert result == "안녕하세요 반갑습니다"
-        mock_model.transcribe.assert_called_once_with("/fake/path.mp3", beam_size=5)
+        mock_model.transcribe.assert_called_once()
+        args, kwargs = mock_model.transcribe.call_args
+        assert args == ("/fake/path.mp3",)
+        assert kwargs["language"] == "ko"
+        assert kwargs["beam_size"] == 5
+        assert kwargs["vad_filter"] is True
+        assert "vad_parameters" in kwargs
+        assert kwargs["initial_prompt"]  # 비어있지 않음
+        assert kwargs["temperature"] == [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+        assert kwargs["compression_ratio_threshold"] == 2.4
+        assert kwargs["no_speech_threshold"] == 0.6
 
     @patch("app.services.stt.get_model")
     def test_transcribe_empty_raises(self, mock_get_model):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -783,7 +783,7 @@ wheels = [
 
 [[package]]
 name = "notebot-backend"
-version = "0.1.0"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- faster-whisper 호출에 한국어 학습 도메인 최적화 옵션 추가
- 추상화 작업(M1) 전, 가장 적은 변경으로 사용자 체감 정확도 향상
- v1.5 계획의 첫 마일스톤(M0). 후속: M1 STT Provider 추상화

## 변경 옵션 분해

| 옵션 | 효과 |
|---|---|
| `language="ko"` | 자동 감지 단계 제거 → 짧은 클립 영어 오감지 차단, 0.5–1초 단축 |
| `vad_filter=True` (Silero VAD) | 침묵 구간 스킵 → 환각 단어 감소, 처리 시간 단축 |
| `initial_prompt` (학습 도메인) | 강의·교재 같은 도메인 어휘 인식률 향상 |
| `temperature=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0]` | 디코딩 실패 시 점진적 재시도 → 환각 발생률 ↓ |
| `compression_ratio_threshold=2.4` | 같은 단어 반복 환각 (예: "네 네 네 네") 차단 |
| `no_speech_threshold=0.6` | 침묵 구간 텍스트 출력 안정화 |

## 신규 설정 (`.env` 오버라이드 가능)
- `STT_LANGUAGE` (기본 `"ko"`)
- `STT_VAD_ENABLED` (기본 `True`)
- `STT_VAD_MIN_SILENCE_MS` (기본 `500`)
- `STT_DEFAULT_INITIAL_PROMPT` (기본 학습 도메인 한국어 프롬프트)

## 변경 파일
- `backend/app/services/stt.py` — `transcribe_file`에 옵션 추가
- `backend/app/config.py` — `STT_*` 설정 4개 추가
- `backend/tests/test_stt.py` — 새 인자 전달 검증 갱신
- `backend/uv.lock` — release-please의 backend 1.1.0 갱신 동기화

## 회귀 안전성
- `transcribe_file` 시그니처 그대로 (`(file_path: str) -> str`)
- 호출자([upload.py:110](backend/app/routers/upload.py#L110)) 변경 불필요
- 전체 테스트 48/48 통과 (`uv run pytest -q`)

## Test plan
- [x] `uv run pytest tests/test_stt.py` 통과
- [x] 전체 백엔드 테스트 48개 통과
- [ ] 한국어 강의 샘플 1개로 수동 비교 — 영어 오인식·반복 환각 감소 확인 (PR 머지 전 권장)

## v1.5 후속 마일스톤 미리보기
- **M1**: STT Provider 추상화 (`BaseSttProvider` ABC + Factory) — 본 PR의 옵션이 `SttOptions` DTO로 이동
- **M2**: Alembic 도입
- **M3**: YouTube Source 인제스트 (yt-dlp + 자막 fast-path)
- **M4**: UI/UX 전면 개편 (Bento + Soft Glass)
- **M5+**: 인증·Project·Vocabulary·Quiz 등

전체 계획: [/Users/gdpark/.claude/plans/rag-linear-beacon.md](로컬 plan 파일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration options for speech-to-text including language selection, voice activity detection (VAD) with configurable minimum silence duration, and custom initial prompts for transcription.
  * Speech-to-text transcription processing now uses centralized configuration parameters providing enhanced control over language, beam search depth, compression ratio detection, speech/silence thresholds, and temperature settings during model inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->